### PR TITLE
refactor(common): adding accordion-table component

### DIFF
--- a/src/@aui/app/App.tsx
+++ b/src/@aui/app/App.tsx
@@ -1,25 +1,14 @@
 import React, { useMemo } from 'react';
-import { useAUITable, AUITable } from '@aui/common/Table/table';
+import apacheNifiImg from '@aui/assets/apache-nifi.png'
 import { withAUITheme, AUITypography } from '@aui/util'
-import { Accordion, AccordionSummary, AccordionDetails, Button, Grid, makeStyles } from '@material-ui/core'
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
-import apacheNifiImg from '../assets/apache-nifi.png'
+import { makeStyles } from '@material-ui/core'
 import { StatusText } from '@aui/common';
 import { Column } from 'react-table'
-import { I18nProvider } from '@lingui/react'
-import { Trans } from '@lingui/macro'
+import { I18nLoader } from '@aui/common'
+import { AccordionTable } from '@aui/common'
+import { t } from '@lingui/macro'
 
 const useStyles = makeStyles({
-  right: {
-    float: 'right'
-  },
-  sectionTitleText: {
-    marginLeft: '40px',
-    marginTop: '15px'
-  },
-  sectionSubtitleText: {
-    marginLeft: '15px'
-  },
   lastRunText: {
     marginTop: '10px'
   }
@@ -89,52 +78,17 @@ function _App() {
   ], [classes])
 
   //TODO add correct type
-  const instance = useAUITable<any>({
-    columns,
-    data
-  })
+  
   return (
-    <I18nProvider language="en">
-      <Accordion>
-          <AccordionSummary
-            expandIcon={<ExpandMoreIcon color="primary" />}
-            aria-controls="expand-panel-content"
-            id="expand-panel-header"
-          >
-            <img 
-              src={apacheNifiImg} 
-              alt='Apache Nifi'
-              width="120"
-              height="50"
-            />
-            <AUITypography kind="sectionTitle" className={classes.sectionTitleText}>
-              <Trans>Apache NiFi</Trans>
-            </AUITypography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <Grid container spacing={3}>
-              <Grid item xs={6}>
-                <AUITypography kind="sectionSubtitle" className={classes.sectionSubtitleText}>
-                  <Trans>Process Group(s)</Trans>
-                </AUITypography>
-              </Grid>
-              <Grid item xs={6} >
-                <Button color="primary" className={classes.right}>
-                  <Trans>Open NiFi Dashboard</Trans>
-                </Button>
-              </Grid>
-              <Grid item xs={12}>
-                <AUITable instance={instance} />
-              </Grid>
-              <Grid item xs={3}>
-                <Button variant="outlined" color="primary">
-                  <Trans>Add Process Group</Trans>
-                </Button>
-              </Grid>
-            </Grid>
-          </AccordionDetails>
-      </Accordion>
-    </I18nProvider>
+    <I18nLoader language="en">
+      <AccordionTable 
+        icon={apacheNifiImg} 
+        title={t`Apache NiFi`} 
+        tableTitle={t`Process Group(s)`}
+        columns={columns}
+        data={data}
+      />
+    </I18nLoader>
   )
 }
 

--- a/src/@aui/common/AccordionTable/AccordionTable.tsx
+++ b/src/@aui/common/AccordionTable/AccordionTable.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import { useAUITable, AUITable } from '@aui/common/Table/table'
+import { Accordion, AccordionSummary, AccordionDetails, Button, Grid, makeStyles } from '@material-ui/core'
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
+import { Trans } from '@lingui/macro'
+import { AUITypography } from '@aui/util'
+import { MessageDescriptor } from '@lingui/core'
+import { i18n } from '@aui/common'
+
+
+const useStyles = makeStyles({
+    right: {
+      float: 'right'
+    },
+    sectionTitleText: {
+      marginLeft: '40px',
+      marginTop: '15px'
+    },
+    sectionSubtitleText: {
+      marginLeft: '15px'
+    },
+    lastRunText: {
+      marginTop: '10px'
+    }
+  })
+
+export interface IAccordionTable{
+    icon: string
+    title: MessageDescriptor
+    tableTitle: MessageDescriptor
+    columns: any
+    data: any
+}
+
+export const AccordionTable: React.FC<IAccordionTable> = ({
+    icon,
+    title,
+    tableTitle,
+    columns,
+    data
+}) => {
+    const classes = useStyles({})
+    const instance = useAUITable<any>({
+        columns,
+        data
+      })
+
+    return (
+        <Accordion>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon color="primary" />}
+            aria-controls="expand-panel-content"
+            id="expand-panel-header"
+          >
+            <img 
+              src={icon} 
+              alt='Apache Nifi'
+              width="120"
+              height="50"
+            />
+            <AUITypography kind="sectionTitle" className={classes.sectionTitleText}>
+              {i18n._(title)}
+            </AUITypography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Grid container spacing={3}>
+              <Grid item xs={6}>
+                <AUITypography kind="sectionSubtitle" className={classes.sectionSubtitleText}>
+                  {i18n._(tableTitle)}
+                </AUITypography>
+              </Grid>
+              <Grid item xs={6} >
+                <Button color="primary" className={classes.right}>
+                  <Trans>Open NiFi Dashboard</Trans>
+                </Button>
+              </Grid>
+              <Grid item xs={12}>
+                <AUITable instance={instance} />
+              </Grid>
+              <Grid item xs={3}>
+                <Button variant="outlined" color="primary">
+                  <Trans>Add Process Group</Trans>
+                </Button>
+              </Grid>
+            </Grid>
+          </AccordionDetails>
+      </Accordion>
+    )
+}

--- a/src/@aui/common/AccordionTable/index.ts
+++ b/src/@aui/common/AccordionTable/index.ts
@@ -1,0 +1,1 @@
+export * from './AccordionTable'

--- a/src/@aui/common/I18nLoader/I18nLoader.tsx
+++ b/src/@aui/common/I18nLoader/I18nLoader.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { setupI18n } from '@lingui/core'
+import { I18nProvider } from '@lingui/react'
+
+export const i18n = setupI18n()
+
+interface I18nProps{
+    language: string
+}
+
+export const I18nLoader: React.FC<I18nProps> = ({language, children}) => {
+    return (
+        <I18nProvider language={language} i18n={i18n}>
+            {children}
+        </I18nProvider>
+    )
+}

--- a/src/@aui/common/I18nLoader/index.ts
+++ b/src/@aui/common/I18nLoader/index.ts
@@ -1,0 +1,1 @@
+export * from './I18nLoader'

--- a/src/@aui/common/index.ts
+++ b/src/@aui/common/index.ts
@@ -1,3 +1,5 @@
 export * from './List'
 export * from './Table'
 export * from './StatusText'
+export * from './AccordionTable'
+export * from './I18nLoader'


### PR DESCRIPTION
Refactoring the component as a common component which contains the accordion and then a table inside it. This can then be used across modules. It takes in the title as well as the columns and data.