### PR TITLE
refactor(common): adding HashRouter instead of BrowserRouter

### DIFF
--- a/src/@aui/app/App.tsx
+++ b/src/@aui/app/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { withAUITheme } from '@aui/util'
 import { I18nLoader } from '@aui/common'
-import { Route, BrowserRouter } from 'react-router-dom'
+import { Route, HashRouter } from 'react-router-dom'
 import { NodeGroups } from '@aui/nodeGroups'
 import { ProcessGroups } from '@aui/processGroups'
 import { Home } from './Home'
@@ -9,11 +9,11 @@ import { Home } from './Home'
 function _App() {
   return (
     <I18nLoader language="en">
-      <BrowserRouter>
+      <HashRouter basename="/">
         <Route exact path="/" component={Home} />
         <Route exact path="/process" component={ProcessGroups} />
         <Route exact path="/node" component={NodeGroups} />
-      </BrowserRouter>
+      </HashRouter>
     </I18nLoader>
   )
 }


### PR DESCRIPTION
Using `HashRouter` instead of `BrowserRouter` and adding basename