### PR TITLE
feat(common): support for pluggable components

### DIFF
--- a/src/@aui/app/App.tsx
+++ b/src/@aui/app/App.tsx
@@ -5,6 +5,7 @@ import { Route, HashRouter } from 'react-router-dom'
 import { NodeGroups } from '@aui/nodeGroups'
 import { ProcessGroups } from '@aui/processGroups'
 import { Home } from './Home'
+import { PluginLoader } from './plugins/PluginLoader'
 
 function _App() {
   return (
@@ -14,6 +15,7 @@ function _App() {
         <Route exact path="/process" component={ProcessGroups} />
         <Route exact path="/node" component={NodeGroups} />
       </HashRouter>
+      <PluginLoader />
     </I18nLoader>
   )
 }

--- a/src/@aui/app/plugins/PluginLoader.tsx
+++ b/src/@aui/app/plugins/PluginLoader.tsx
@@ -1,0 +1,33 @@
+import React, { lazy, useState, useEffect, Suspense } from 'react'
+import plugins from './plugin.json'
+
+export const PluginLoader = () => {
+    const [components, setComponents] = useState<any>([])
+
+    const importComponent = (plugin: any) => 
+        lazy(() => 
+            import(`./${plugin.name}/index.tsx`)
+        )
+
+    useEffect(() => {
+        async function loadPlugins() {
+            const componentPromises = plugins.map(async plugin => {
+                const Component: any = await importComponent(plugin)
+                return <Component key={plugin.name} />
+            })
+
+            Promise.all(componentPromises).then(setComponents)
+        }
+
+        loadPlugins()
+    }, [])
+
+    return (
+        <>
+        <div>Test plugin framework</div>
+        <Suspense fallback='Loading views...'>
+            <div>{components}</div>
+        </Suspense>
+        </>
+    )
+}

--- a/src/@aui/app/plugins/myTestPlugin/index.tsx
+++ b/src/@aui/app/plugins/myTestPlugin/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const MyTestPlugin = () => {
+    return (
+        <div>My Test Plugin</div>
+    )
+}
+
+export default () => <MyTestPlugin />

--- a/src/@aui/app/plugins/plugin.json
+++ b/src/@aui/app/plugins/plugin.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "myTestPlugin",
+    "type": "dashboardCard",
+    "entry": "index.tsx"
+  }
+]


### PR DESCRIPTION
This adds support for loading third party developed components via a plugin based architecture. This has a plugin configuration file which takes in the plugin (component) name along with the entry file (like index.tsx file). It then loads all the plugins on the home page based on the configuration.

Next steps - 

1. To add support for type based plugins - like dashboard, menu etc.
2. To add appropriate types
