### PR TITLE
feat(common): adding draggable support for widgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "gh-pages": "^3.1.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-draggable": "^4.4.3",
     "react-redux": "^7.2.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.1",

--- a/src/@aui/app/plugins/WidgetComponent.tsx
+++ b/src/@aui/app/plugins/WidgetComponent.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import Draggable from 'react-draggable'
 
 export interface PluginProps {
     id: string
@@ -59,5 +60,12 @@ export const withWidget = (pluginProps: PluginProps) => <P extends object>(Compo
         setWidgetProps({eventMessage, onEventComplete: handleEventComplete})
     }, [eventMessage, handleEventComplete])
 
-    return <Component {...props} {...widgetProps} />
+    //Need a div inside Draggable to enable dragging. Does not work without it!
+    return (
+        <Draggable>
+            <div>
+            <Component {...props} {...widgetProps} />
+            </div>
+        </Draggable>
+    )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12183,7 +12183,7 @@ react-dom@^16.13.1, react-dom@^16.8.3:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-draggable@^4.0.3:
+react-draggable@^4.0.3, react-draggable@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.3.tgz#0727f2cae5813e36b0e4962bf11b2f9ef2b406f3"
   integrity sha512-jV4TE59MBuWm7gb6Ns3Q1mxX8Azffb7oTtDtBgFkxRvhDp38YAARmRplrj0+XGkhOJB5XziArX+4HUUABtyZ0w==


### PR DESCRIPTION
Adding `react-draggable` and wrapping the widgets with `Draggable` component to enable dragging of components.