### PR TITLE
feat(common): adding widgets to the react-grid

### DIFF
--- a/src/@aui/app/plugins/PluginLoader.tsx
+++ b/src/@aui/app/plugins/PluginLoader.tsx
@@ -5,6 +5,18 @@ import { Snackbar, IconButton } from '@material-ui/core'
 import CloseIcon from '@material-ui/icons/Close'
 import { withWidget, PluginProps } from './WidgetComponent'
 
+export const loadPlugin = async (plugin: PluginProps) => {
+
+    const importComponent = (plugin: any) => 
+        lazy(() => 
+            import(`./${plugin.name}/index.ts`)
+        )
+    
+    const PluginComponent = await importComponent(plugin)
+    const UIWidget = withWidget(plugin as PluginProps)(PluginComponent)
+    return <UIWidget key={plugin.id} />
+}
+
 export const PluginLoader = () => {
     const [components, setComponents] = useState<any>([])
     const [open, setOpen] = useState(false)

--- a/src/@aui/app/plugins/nodeGroups/NodeGroups.tsx
+++ b/src/@aui/app/plugins/nodeGroups/NodeGroups.tsx
@@ -19,8 +19,8 @@ const useStyles = makeStyles({
   })
 
 interface NodeGroupsProps{
-    eventMessage: any
-    onEventComplete: (param: any) => void
+    eventMessage?: any
+    onEventComplete?: (param: any) => void
 }
 
 const NodeGroups: React.FC<NodeGroupsProps> = (props) => {


### PR DESCRIPTION
This flow lets users add a new tile to the dashboard. The tile options are all the widgets registered as plugins via the plugin configuration file. The tile width and height are currently hard coded but will be made flexible for the users creating the dashboard.