### PR TITLE
feat(common): support for custom dashboards

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@lingui/react": "^2.9.1",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.56",
     "@testing-library/jest-dom": "^5.11.2",
     "@testing-library/react": "^10.4.7",
     "@testing-library/user-event": "^12.0.17",

--- a/src/@aui/app/App.tsx
+++ b/src/@aui/app/App.tsx
@@ -4,6 +4,7 @@ import { I18nLoader } from '@aui/common'
 import { Route, HashRouter } from 'react-router-dom'
 import { Dashboard } from './Dashboard'
 import { DashboardMaker } from '../dashboards'
+import { DashboardViewer } from '../dashboards'
 import { Home } from './Home'
 import NodeGroups from './plugins/nodeGroups'
 import ProcessGroups from './plugins/processGroups'
@@ -20,6 +21,7 @@ function _App() {
           <Route exact path="/node" component={NodeGroups} />
           <Route exact path="/dashboard" component={Dashboard} />
           <Route exact path="/dashboardMaker" component={DashboardMaker} />
+          <Route exact path="/dashboards" component={DashboardViewer} />
         </HashRouter>
       </I18nLoader>
     </Provider>

--- a/src/@aui/app/Home.tsx
+++ b/src/@aui/app/Home.tsx
@@ -10,6 +10,7 @@ export const Home = () => {
                 <li><NavLink to="/process">UI Component - Process Group</NavLink></li>
                 <li><NavLink to="/node">UI Component - Node Group</NavLink></li>
                 <li><NavLink to="/dashboardMaker">Dashboard Maker</NavLink></li>
+                <li><NavLink to="/dashboards">Dashboard Viewer</NavLink></li>
             </ul>
         </>
     )

--- a/src/@aui/app/plugins/PluginLoader.tsx
+++ b/src/@aui/app/plugins/PluginLoader.tsx
@@ -9,12 +9,12 @@ export const loadPlugin = async (plugin: PluginProps) => {
 
     const importComponent = (plugin: any) => 
         lazy(() => 
-            import(`./${plugin.name}/index.ts`)
+            import(`./${plugin.key}/index.ts`)
         )
     
     const PluginComponent = await importComponent(plugin)
     const UIWidget = withWidget(plugin as PluginProps)(PluginComponent)
-    return <UIWidget key={plugin.id} />
+    return <UIWidget key={plugin.key} />
 }
 
 export const PluginLoader = () => {
@@ -30,7 +30,7 @@ export const PluginLoader = () => {
 
     const importComponent = (plugin: any) => 
         lazy(() => 
-            import(`./${plugin.name}/index.ts`)
+            import(`./${plugin.key}/index.ts`)
         )
 
     useEffect(() => {
@@ -38,7 +38,7 @@ export const PluginLoader = () => {
             const componentPromises = plugins.map(async plugin => {
                 const PluginComponent = await importComponent(plugin)
                 const UIWidget = withWidget(plugin as PluginProps)(PluginComponent)
-                return <UIWidget key={plugin.id} />
+                return <UIWidget key={plugin.key} />
             })
 
             Promise.all(componentPromises).then(setComponents)

--- a/src/@aui/app/plugins/WidgetComponent.tsx
+++ b/src/@aui/app/plugins/WidgetComponent.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import Draggable from 'react-draggable'
 
 export interface PluginProps {
-    id: string
+    key: string
     name: string
     type: string
     entry: string

--- a/src/@aui/app/plugins/plugin.json
+++ b/src/@aui/app/plugins/plugin.json
@@ -1,13 +1,13 @@
 [
   {
-    "id": "nodeGroups",
+    "key": "nodeGroups",
     "name": "nodeGroups",
     "displayName": "Node Groups",
     "type": "dashboardCard",
     "entry": "index.tsx"
   },
   {
-    "id": "processGroups",
+    "key": "processGroups",
     "name": "processGroups",
     "displayName": "Process Groups",
     "type": "dashboardCard",

--- a/src/@aui/common/useLocalStorage.ts
+++ b/src/@aui/common/useLocalStorage.ts
@@ -1,0 +1,29 @@
+import { useState, useCallback } from 'react'
+
+export function useLocalStorage<T = any>(
+    key: string,
+    initialValue: T
+): [T, (value:T) => void] {
+
+    const [storedValue, setStoredValue] = useState(() => {
+        try{
+            const item = window.localStorage.getItem(key)
+            return item ? JSON.parse(item) : initialValue
+        }catch(err){
+            return initialValue
+        }
+    })
+
+    const setValue = useCallback((value: T) => {
+        try{
+            if(key){
+                setStoredValue(value)
+                window.localStorage.setItem(key, JSON.stringify(value))
+            }
+        }catch(error){
+            console.log(error)
+        }
+    }, [key])
+
+    return [storedValue, setValue]
+}

--- a/src/@aui/dashboards/common/DashboardGridLayout.tsx
+++ b/src/@aui/dashboards/common/DashboardGridLayout.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from 'react' 
+import React, { useEffect, useState, useCallback } from 'react' 
 import GridLayout from 'react-grid-layout'
+import { useLocalStorage } from '@aui/common/useLocalStorage';
 
 interface DashboardGridLayoutProps {
     plugins: any
@@ -7,28 +8,57 @@ interface DashboardGridLayoutProps {
 
 export const _DashboardGridLayout: React.FC<DashboardGridLayoutProps> = ({plugins}) => {
     const [layout, setLayout] = useState<any>([])
+    const [value, setValue] = useLocalStorage<any>('dashboardLayout', [])
+
+    const handleOnLayoutChange: (currentLayout: any[]) => any = useCallback((currentLayout: any) => {
+        const layoutValues = [...value]
+        if(currentLayout && currentLayout.length){
+            currentLayout.forEach((newLayout: any) => {
+                const layoutFound = layoutValues.find(layoutVal => layoutVal.id === newLayout.i)
+                if(layoutFound){
+                    layoutFound.layout = newLayout
+                }
+            })
+        }
+        setValue(layoutValues)
+    }, [value, setValue])
 
     useEffect(() => {
+        const pluginLayouts: any[] = []
         const layouts = plugins.map((plugin: any, index: any) => {
-            return {
+            const layout = {
                 i: plugin.key, 
                 x: (index * 6) % 12,
                 y: index * 12,
                 w: 6,
                 h: 12
             }
+            const pluginIndex = pluginLayouts.findIndex((pluginLayout) => {
+                return pluginLayout.id === plugin.key
+            })
+            if(pluginIndex === -1){
+                pluginLayouts.push({
+                    id: plugin.key,
+                    layout,
+                    plugin
+                })
+            }
+            return layout
         })
         setLayout(layouts)
-    }, [plugins])
+        setValue(pluginLayouts)
+    }, [plugins, setValue])
 
     return (
-        <GridLayout className="layout" layout={layout} width={1200} cols={12}>
+        <>
+        <GridLayout className="layout" layout={layout} width={1200} cols={12} onLayoutChange={(currentLayout) => handleOnLayoutChange(currentLayout)}>
             {
                 plugins.map((plugin: any, index: any) => (                            
                     <div key={plugin.key}>{plugin}</div>
                 ))
             }
         </GridLayout>
+        </>
     )
 }
 

--- a/src/@aui/dashboards/common/DashboardMaker.tsx
+++ b/src/@aui/dashboards/common/DashboardMaker.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, Suspense } from 'react'
-import { AppBar, Toolbar, Button, makeStyles, Dialog, DialogTitle, DialogActions, DialogContent, Grid, Card, CardContent } from '@material-ui/core'
+import { AppBar, Toolbar, Button, makeStyles, Dialog, Snackbar, DialogTitle, DialogActions, DialogContent, Grid, Card, CardContent, TextField } from '@material-ui/core'
+import MuiAlert from '@material-ui/lab/Alert'
 import { AUITypography } from '@aui/util'
 import { Trans }  from '@lingui/macro'
 import plugins from '@aui/app/plugins/plugin.json'
@@ -7,6 +8,7 @@ import { lightOrange } from '@aui/util'
 import isEmpty from 'lodash/isEmpty'
 import { loadPlugin } from '@aui/app/plugins'
 import { DashboardGridLayout } from './DashboardGridLayout'
+import { useLocalStorage } from '@aui/common/useLocalStorage'
 
 
 const useStyles = makeStyles({
@@ -26,6 +28,19 @@ export const DashboardMaker = () => {
     const [isAddTileOpen, setIsAddTileOpen] = useState(false)
     const [selectedPlugin, setSelectedPlugin] = useState<any>({})
     const [loadedPlugins, setLoadedPlugins] = useState<any>([])
+    const [layoutValue] = useLocalStorage('dashboardLayout', [])
+    const [savedDashboardValues, setSavedDashboardValues] = useLocalStorage<any>('savedDashboard', [])
+    const [dashboardName, setDashboardName] = useState('')
+    const [isDashboardPublishOpen, setIsDashboardPublishOpen] = useState(false)
+    const [openSnackbar, setOpenSnackbar] = useState(false)
+
+    const handleSnackbarClose = () => {
+        setOpenSnackbar(false)
+    }
+
+    const handleDashboardPublishClose = () => {
+        setIsDashboardPublishOpen(false)
+    }
 
     const handleAddTile = () => {
         setIsAddTileOpen(true)   
@@ -51,6 +66,24 @@ export const DashboardMaker = () => {
         }
     }, [loadedPlugins, selectedPlugin])
 
+    const handleDashboardPublish = () => {
+        setIsDashboardPublishOpen(true)
+    }
+
+    const handlePublish = useCallback(() => {
+        if(dashboardName && layoutValue){
+            setSavedDashboardValues([...savedDashboardValues, {dashboardName: dashboardName, pluginLayouts: layoutValue}])
+            setIsDashboardPublishOpen(false)
+            setOpenSnackbar(true)
+        }
+    }, [layoutValue, dashboardName, savedDashboardValues, setSavedDashboardValues])
+
+    const handleDashboardNameChange = (event: any) => {
+        if(event && event.target.value){
+            setDashboardName(event.target.value)
+        }
+    }
+
     return (
         <>
             <AppBar position="static">
@@ -58,7 +91,7 @@ export const DashboardMaker = () => {
                     <AUITypography kind="sectionSubtitle" className={classes.title}>
                         Dashboard Maker
                     </AUITypography>
-                    <Button>
+                    <Button onClick={handleDashboardPublish}>
                         <Trans>Publish as Dashboard</Trans>
                     </Button>
                     <Button variant="contained" onClick={handleAddTile}>
@@ -92,8 +125,8 @@ export const DashboardMaker = () => {
                             {
                                 plugins.map((plugin: any) => {
                                     return (
-                                        <Grid item xs={3} key={plugin.id}>
-                                            <Card onClick={() => handlePluginSelection(plugin)} className={plugin.id === selectedPlugin.id ? classes.selectedPlugin : ''}>
+                                        <Grid item xs={3} key={plugin.key}>
+                                            <Card onClick={() => handlePluginSelection(plugin)} className={plugin.key === selectedPlugin.key ? classes.selectedPlugin : ''}>
                                                 <CardContent>
                                                     <AUITypography kind="sectionSubtitle">{plugin.displayName}</AUITypography>
                                                 </CardContent>
@@ -109,11 +142,41 @@ export const DashboardMaker = () => {
                         <Button onClick={handleClose}>
                             <Trans>Cancel</Trans>
                         </Button>
-                        <Button variant="contained" color="primary" onClick={handleTileSelection} disabled={isEmpty(selectedPlugin)}>
+                        <Button variant="contained" color="primary" onClick={() => handleTileSelection()} disabled={isEmpty(selectedPlugin)}>
                             <Trans>Add</Trans>
                         </Button>
                     </DialogActions>
             </Dialog>
+
+            <Dialog
+                open={isDashboardPublishOpen}
+                onClose={handleDashboardPublishClose}
+                aria-labelledby="simple-modal-title"
+                aria-describedby="simple-modal-description"
+                >
+                    <DialogTitle>
+                        <AUITypography kind="sectionSubtitle">Save as a Dashboard</AUITypography>
+                    </DialogTitle>
+                    <DialogContent>
+                        <AUITypography kind="sectionTextGray">
+                            You can view the saved dashboard via the Dashboard Viewer
+                        </AUITypography>
+                        <TextField id="dashboardName" label="Dashboard Name" value={dashboardName} onChange={handleDashboardNameChange}></TextField>
+                    </DialogContent>
+                    <DialogActions>
+                        <Button onClick={handleDashboardPublishClose}>
+                            <Trans>Cancel</Trans>
+                        </Button>
+                        <Button variant="contained" color="primary" disabled={isEmpty(dashboardName)} onClick={() => handlePublish()}>
+                            <Trans>Add</Trans>
+                        </Button>
+                    </DialogActions>
+            </Dialog>
+            <Snackbar open={openSnackbar} autoHideDuration={6000} onClose={handleSnackbarClose}>
+                <MuiAlert elevation={6} variant="filled" onClose={handleSnackbarClose} severity="success">
+                    Custom dashboard created!
+                </MuiAlert>
+            </Snackbar>
         </>
     )
 }

--- a/src/@aui/dashboards/common/index.ts
+++ b/src/@aui/dashboards/common/index.ts
@@ -1,1 +1,2 @@
 export * from './DashboardMaker'
+export * from './DashboardGridLayout'

--- a/src/@aui/dashboards/index.ts
+++ b/src/@aui/dashboards/index.ts
@@ -1,1 +1,2 @@
 export * from './common'
+export * from './viewer'

--- a/src/@aui/dashboards/viewer/DashboardViewer.tsx
+++ b/src/@aui/dashboards/viewer/DashboardViewer.tsx
@@ -1,0 +1,98 @@
+import React, { useState, Suspense } from 'react'
+import { AUITypography } from '@aui/util'
+import { useLocalStorage } from '@aui/common/useLocalStorage'
+import { AppBar, Toolbar, makeStyles, Drawer, List, ListItem, ListItemText, ListItemIcon } from '@material-ui/core'
+import { loadPlugin } from '@aui/app/plugins'
+import GridLayout from 'react-grid-layout'
+
+const drawerWidth = 240
+
+const useStyles = makeStyles((theme) => ({
+    root: {
+      display: 'flex',
+    },
+    appBar: {
+      zIndex: theme.zIndex.drawer + 1,
+    },
+    drawer: {
+      width: drawerWidth,
+      flexShrink: 0,
+    },
+    drawerPaper: {
+      width: drawerWidth,
+    },
+    drawerContainer: {
+      overflow: 'auto',
+    },
+    content: {
+      flexGrow: 1,
+      marginLeft: '300px',
+      padding: theme.spacing(3),
+    },
+  }))
+
+export const DashboardViewer = () => {
+    const classes = useStyles()
+    const [savedDashboards] = useLocalStorage('savedDashboard', [])
+    const [loadedPlugins, setLoadedPlugins] = useState<any>([])
+    const [layout, setLayout] = useState([])
+
+    const handleDashboardOpen = (savedDashboard: any) => {
+        const { pluginLayouts } = savedDashboard
+        const componentPromises = pluginLayouts.map(async (pluginLayout: any) => {
+          return loadPlugin(pluginLayout.plugin)
+        })
+
+        const layouts = pluginLayouts.map((pluginLayout: any) => pluginLayout.layout)
+        setLayout(layouts)
+
+        Promise.all(componentPromises).then(setLoadedPlugins)
+    }
+
+    return (
+        <div>
+            <AppBar position="fixed" className={classes.appBar}>
+                <Toolbar>
+                <AUITypography kind="sectionTitle" noWrap>
+                    Dashboard Viewer
+                </AUITypography>
+                </Toolbar>
+            </AppBar>
+            <Drawer
+                className={classes.drawer}
+                variant="permanent"
+                classes={{
+                paper: classes.drawerPaper,
+                }}
+            >
+                <Toolbar />
+                <div className={classes.drawerContainer}>
+                <List>
+                    {savedDashboards.map((savedDashboard: any, index) => (
+                    <ListItem button key={savedDashboard.dashboardName} onClick={() => handleDashboardOpen(savedDashboard)}>
+                        <ListItemIcon></ListItemIcon>
+                        <ListItemText primary={savedDashboard.dashboardName} />
+                    </ListItem>
+                    ))}
+                </List>
+                </div>
+            </Drawer>
+            <main className={classes.content}>
+                <Toolbar />
+                {loadedPlugins && loadedPlugins.length ?
+                (
+                    <Suspense fallback="Loading grid">
+                      <GridLayout className="layout" layout={layout} width={1200} cols={12}>
+                          {
+                              loadedPlugins.map((plugin: any, index: any) => (                            
+                                  <div key={plugin.key}>{plugin}</div>
+                              ))
+                          }
+                      </GridLayout>
+                    </Suspense>
+                ) : null
+              }
+            </main>
+      </div>
+    )
+}

--- a/src/@aui/dashboards/viewer/index.ts
+++ b/src/@aui/dashboards/viewer/index.ts
@@ -1,0 +1,1 @@
+export * from './DashboardViewer'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1693,6 +1693,17 @@
   dependencies:
     "@babel/runtime" "^7.4.4"
 
+"@material-ui/lab@^4.0.0-alpha.56":
+  version "4.0.0-alpha.56"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.56.tgz#ff63080949b55b40625e056bbda05e130d216d34"
+  integrity sha512-xPlkK+z/6y/24ka4gVJgwPfoCF4RCh8dXb1BNE7MtF9bXEBLN/lBxNTK8VAa0qm3V2oinA6xtUIdcRh0aeRtVw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.10.2"
+    clsx "^1.0.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0"
+
 "@material-ui/styles@^4.10.0":
   version "4.10.0"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.10.0.tgz#2406dc23aa358217aa8cc772e6237bd7f0544071"


### PR DESCRIPTION
Adding support to create custom dashboards. There is a Dashboard Maker that allows the user to pick the widgets they would like on the dashboard. Then the user has a Publish as dashboard to create a custom dashboard that is then viewed from the Dashboard Viewer.